### PR TITLE
[Preview][Data] Avoid concatenating multi-chunk tensor columns during row takes

### DIFF
--- a/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
+++ b/python/ray/dashboard/modules/platform_events/tests/test_k8s_provider.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from kubernetes.client.rest import ApiException
 
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.core.generated.platform_event_pb2 import Source
@@ -327,6 +326,8 @@ def test_resolve_cluster_pod_cold_miss_not_matching_label_caches_negative():
 
 
 def test_resolve_cluster_pod_deleted_pod_counts_as_not_member():
+    from kubernetes.client.rest import ApiException
+
     provider = KubernetesEventProvider(lambda e: None)
     provider._cluster_name = "my-cluster"
     provider._namespace = "ns"

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -186,6 +186,70 @@ def hash_partition(
     }
 
 
+def _try_normalize_take_indices(
+    indices: Union[List[int], np.ndarray, "pyarrow.Array", "pyarrow.ChunkedArray"],
+    row_count: int,
+) -> Optional[np.ndarray]:
+    """Return native int64 indices suitable for the tensor fast path."""
+    if isinstance(indices, (np.ma.MaskedArray, pyarrow.ChunkedArray)):
+        return None
+
+    if isinstance(indices, pyarrow.Array):
+        if indices.null_count > 0 or not pyarrow.types.is_integer(indices.type):
+            return None
+        try:
+            values = indices.to_numpy(zero_copy_only=False)
+        except (
+            pyarrow.ArrowInvalid,
+            pyarrow.ArrowNotImplementedError,
+            TypeError,
+            ValueError,
+        ):
+            return None
+    elif isinstance(indices, list):
+        try:
+            arrow_indices = pyarrow.array(indices)
+        except (
+            pyarrow.ArrowInvalid,
+            pyarrow.ArrowTypeError,
+            TypeError,
+            ValueError,
+            OverflowError,
+        ):
+            return None
+        if arrow_indices.null_count > 0 or not pyarrow.types.is_integer(
+            arrow_indices.type
+        ):
+            return None
+        try:
+            values = arrow_indices.to_numpy(zero_copy_only=False)
+        except (
+            pyarrow.ArrowInvalid,
+            pyarrow.ArrowNotImplementedError,
+            TypeError,
+            ValueError,
+        ):
+            return None
+    elif isinstance(indices, np.ndarray):
+        try:
+            values = np.asarray(indices)
+        except (TypeError, ValueError, OverflowError):
+            return None
+    else:
+        return None
+
+    if isinstance(indices, np.ndarray) and not indices.dtype.isnative:
+        return None
+    if values.ndim != 1 or values.dtype.kind not in "iu":
+        return None
+    if values.size > 0:
+        if values.dtype.kind == "i" and np.any(values < 0):
+            return None
+        if np.any(values >= row_count):
+            return None
+    return values.astype(np.int64, copy=False)
+
+
 def take_table(
     table: "pyarrow.Table",
     indices: Union[List[int], np.ndarray, "pyarrow.Array", "pyarrow.ChunkedArray"],
@@ -202,9 +266,29 @@ def take_table(
     )
 
     if any(_is_pa_extension_type(col.type) for col in table.columns):
+        normalized_indices = None
+        if any(
+            _is_pa_extension_type(col.type) and col.num_chunks > 1
+            for col in table.columns
+        ):
+            normalized_indices = _try_normalize_take_indices(indices, table.num_rows)
+
+        take_chunked_tensor = None
+        if normalized_indices is not None:
+            from ray.data._internal.tensor_extensions.chunked_tensor_take import (
+                try_take_chunked_tensor,
+            )
+
+            take_chunked_tensor = try_take_chunked_tensor
+
         new_cols = []
         for col in table.columns:
             if _is_pa_extension_type(col.type) and col.num_chunks > 1:
+                if take_chunked_tensor is not None:
+                    taken = take_chunked_tensor(col, normalized_indices)
+                    if taken is not None:
+                        new_cols.append(taken)
+                        continue
                 # .take() will concatenate internally, which currently breaks for
                 # extension arrays.
                 col = _concatenate_extension_column(col)

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -238,7 +238,7 @@ def _try_normalize_take_indices(
     else:
         return None
 
-    if isinstance(indices, np.ndarray) and not indices.dtype.isnative:
+    if not values.dtype.isnative:
         return None
     if values.ndim != 1 or values.dtype.kind not in "iu":
         return None

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.arrow_ops import transform_pyarrow
-from ray.data._internal.arrow_ops.transform_pyarrow import try_combine_chunked_columns
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.util import get_total_obj_store_mem_on_node
@@ -22,6 +21,69 @@ SHUFFLE_BUFFER_COMPACTION_RATIO = 1.5
 # compaction (and re-shuffling of indices) is triggered. Experiments show 0.5
 # is a good trade-off between throughput and randomness.
 SHUFFLE_BUFFER_COMPACTION_THRESHOLD = 0.5
+
+
+def _prepare_local_shuffle_arrow_table(table, *, max_output_rows: int):
+    """Combine ordinary columns and prepare eligible tensor source chunks."""
+    import pyarrow as pa
+
+    from ray.data._internal.utils.transform_pyarrow import _is_pa_extension_type
+
+    if not any(
+        column.num_chunks > 1 and _is_pa_extension_type(column.type)
+        for column in table.columns
+    ):
+        return (
+            transform_pyarrow.try_combine_chunked_columns(table, 1),
+            {},
+        )
+
+    from ray.data._internal.tensor_extensions.chunked_tensor_take import (
+        try_prepare_chunked_tensor_take,
+    )
+
+    prepared_plans = {}
+    for index, column in enumerate(table.columns):
+        if column.num_chunks <= 1:
+            continue
+        plan = try_prepare_chunked_tensor_take(
+            column,
+            max_output_rows=max_output_rows,
+        )
+        if plan is not None:
+            prepared_plans[index] = plan
+
+    if not prepared_plans:
+        return transform_pyarrow.try_combine_chunked_columns(table, 1), {}
+
+    columns = []
+    for index, column in enumerate(table.columns):
+        if index in prepared_plans or column.num_chunks <= 1:
+            columns.append(column)
+        else:
+            columns.append(transform_pyarrow.combine_chunked_array(column))
+    return pa.Table.from_arrays(columns, schema=table.schema), prepared_plans
+
+
+def _take_prepared_arrow_table(table, indices: np.ndarray, prepared_plans):
+    """Take one batch while reusing validated tensor source metadata."""
+    import pyarrow as pa
+
+    from ray.data._internal.tensor_extensions.chunked_tensor_take import (
+        try_take_prepared_chunked_tensor,
+    )
+
+    columns = []
+    for index, column in enumerate(table.columns):
+        plan = prepared_plans.get(index)
+        if plan is None:
+            columns.append(column.take(indices))
+            continue
+        taken = try_take_prepared_chunked_tensor(plan, indices)
+        if taken is None:
+            return None
+        columns.append(taken)
+    return pa.Table.from_arrays(columns, schema=table.schema)
 
 
 class BatcherInterface:
@@ -231,6 +293,7 @@ class ShufflingBatcher(BatcherInterface):
         self._shuffled_indices: Optional[np.ndarray] = None
         self._batch_head = 0
         self._done_adding = False
+        self._prepared_tensor_take_plans = {}
 
         self._total_object_store_nbytes = get_total_obj_store_mem_on_node()
         self._total_num_rows_added = 0
@@ -341,20 +404,26 @@ class ShufflingBatcher(BatcherInterface):
             self._done_adding
             or self._num_compacted_rows() <= self._min_rows_to_yield_batch
         ):
-            if self._shuffle_buffer is not None and self._batch_head < len(
-                self._shuffled_indices
-            ):
-                remaining_indices = self._shuffled_indices[self._batch_head :]
-                remaining_block = BlockAccessor.for_block(self._shuffle_buffer).take(
-                    remaining_indices
-                )
-                self._builder.add_block(remaining_block)
+            self._prepared_tensor_take_plans = {}
+            if self._shuffle_buffer is not None:
+                assert self._shuffled_indices is not None
+                if self._batch_head < len(self._shuffled_indices):
+                    remaining_indices = self._shuffled_indices[self._batch_head :]
+                    remaining_block = BlockAccessor.for_block(
+                        self._shuffle_buffer
+                    ).take(remaining_indices)
+                    self._builder.add_block(remaining_block)
             self._shuffle_buffer = self._builder.build()
 
             accessor = BlockAccessor.for_block(self._shuffle_buffer)
+            prepared_plans = {}
             if isinstance(accessor, ArrowBlockAccessor):
-                self._shuffle_buffer = try_combine_chunked_columns(
-                    self._shuffle_buffer, min_chunks_to_combine=1
+                (
+                    self._shuffle_buffer,
+                    prepared_plans,
+                ) = _prepare_local_shuffle_arrow_table(
+                    self._shuffle_buffer,
+                    max_output_rows=min(self._batch_size, accessor.num_rows()),
                 )
                 accessor = BlockAccessor.for_block(self._shuffle_buffer)
 
@@ -363,6 +432,7 @@ class ShufflingBatcher(BatcherInterface):
 
             self._builder = DelegatingBlockBuilder()
             self._batch_head = 0
+            self._prepared_tensor_take_plans = prepared_plans
 
         assert self._shuffle_buffer is not None
         assert self._shuffled_indices is not None
@@ -372,4 +442,13 @@ class ShufflingBatcher(BatcherInterface):
             self._batch_head : self._batch_head + batch_size
         ]
         self._batch_head += batch_size
+
+        if self._prepared_tensor_take_plans:
+            batch = _take_prepared_arrow_table(
+                self._shuffle_buffer,
+                batch_indices,
+                self._prepared_tensor_take_plans,
+            )
+            if batch is not None:
+                return batch
         return BlockAccessor.for_block(self._shuffle_buffer).take(batch_indices)

--- a/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
+++ b/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
@@ -1,0 +1,436 @@
+import math
+from itertools import chain
+from typing import Any, NamedTuple
+
+import numpy as np
+import pyarrow as pa
+
+# Cap for simultaneously allocated per-subbatch NumPy gather/index buffers.
+# The final output, Arrow offsets, and zero-copy chunk-view metadata are excluded.
+TENSOR_TAKE_SCRATCH_CAP_BYTES = 8 * 1024 * 1024
+# Narrow large columns stay on Ray's native path because grouping can cost more
+# than the full-column copy it avoids. Small columns remain eligible because their
+# total copy cost is bounded.
+_MIN_FAST_ROW_BYTES = 256
+_SMALL_COLUMN_ROWS = 512
+# Boolean-mask grouping is cheaper for a few chunks; sorting scales better once
+# the number of chunks makes repeated full-subbatch masks expensive.
+_MAX_MASK_GROUP_CHUNKS = 16
+_INDEX_SCRATCH_BYTES_PER_ROW = 64
+_OFFSET_VALIDATION_BLOCK_BYTES = 8 * 1024 * 1024
+
+
+class _ChunkedTensorTakePlan(NamedTuple):
+    """Runtime plan for one chunked tensor take."""
+
+    values_per_row: int
+    value_dtype: np.dtype
+    subbatch_rows: int
+    scratch_bytes: int
+
+
+class PreparedChunkedTensorTakePlan(NamedTuple):
+    """Validated source metadata reusable across takes from one immutable column."""
+
+    tensor_type: Any
+    input_rows: int
+    max_output_rows: int
+    values_per_row: int
+    row_bytes: int
+    value_dtype: np.dtype
+    subbatch_rows: int
+    chunk_views: tuple[np.ndarray, ...]
+    chunk_starts: np.ndarray
+    chunk_ends: np.ndarray
+
+
+def _try_get_chunked_tensor_take_plan(
+    tensor_type,
+    *,
+    input_rows: int,
+    output_rows: int,
+    chunk_count: int,
+) -> _ChunkedTensorTakePlan | None:
+    """Plan an eligible take using the same policy as the runtime fast path.
+
+    The returned scratch estimate covers only simultaneously allocated per-subbatch
+    gather and index buffers. Final output, Arrow offsets, and chunk-view metadata
+    remain the caller's responsibility.
+    """
+    layout = _try_get_tensor_layout(tensor_type)
+    if layout is None or input_rows < 0 or output_rows < 0 or chunk_count <= 1:
+        return None
+
+    values_per_row, row_bytes, value_dtype = layout
+    if input_rows >= _SMALL_COLUMN_ROWS and row_bytes < _MIN_FAST_ROW_BYTES:
+        return None
+    if not _offsets_can_represent_output(tensor_type, output_rows, values_per_row):
+        return None
+
+    subbatch_rows = _tensor_take_subbatch_rows(output_rows, row_bytes)
+    if output_rows > 0 and subbatch_rows == 0:
+        return None
+    return _ChunkedTensorTakePlan(
+        values_per_row=values_per_row,
+        value_dtype=value_dtype,
+        subbatch_rows=subbatch_rows,
+        scratch_bytes=subbatch_rows * (row_bytes + _INDEX_SCRATCH_BYTES_PER_ROW),
+    )
+
+
+def try_prepare_chunked_tensor_take(
+    column: pa.ChunkedArray,
+    *,
+    max_output_rows: int,
+) -> PreparedChunkedTensorTakePlan | None:
+    """Validate and prepare one immutable chunked tensor source for repeated takes."""
+    tensor_type = column.type
+    if column.null_count > 0:
+        return None
+
+    runtime_plan = _try_get_chunked_tensor_take_plan(
+        tensor_type,
+        input_rows=len(column),
+        output_rows=max_output_rows,
+        chunk_count=column.num_chunks,
+    )
+    if runtime_plan is None:
+        return None
+
+    layout = _try_get_tensor_layout(tensor_type)
+    assert layout is not None
+    values_per_row, row_bytes, value_dtype = layout
+    chunk_views = []
+    chunk_starts = []
+    chunk_ends = []
+    row_offset = 0
+    for chunk in column.chunks:
+        view = _try_get_zero_copy_chunk_view(
+            chunk, tensor_type, values_per_row, value_dtype
+        )
+        if view is None:
+            return None
+        if len(chunk) == 0:
+            continue
+        chunk_views.append(view)
+        chunk_starts.append(row_offset)
+        row_offset += len(chunk)
+        chunk_ends.append(row_offset)
+
+    if row_offset != len(column):
+        return None
+
+    return PreparedChunkedTensorTakePlan(
+        tensor_type=tensor_type,
+        input_rows=len(column),
+        max_output_rows=max_output_rows,
+        values_per_row=values_per_row,
+        row_bytes=row_bytes,
+        value_dtype=value_dtype,
+        subbatch_rows=runtime_plan.subbatch_rows,
+        chunk_views=tuple(chunk_views),
+        chunk_starts=np.asarray(chunk_starts, dtype=np.int64),
+        chunk_ends=np.asarray(chunk_ends, dtype=np.int64),
+    )
+
+
+def try_take_prepared_chunked_tensor(
+    plan: PreparedChunkedTensorTakePlan,
+    normalized_indices: np.ndarray,
+) -> pa.Array | None:
+    """Take rows using source validation cached in a prepared plan."""
+    if (
+        not _is_normalized_indices(normalized_indices)
+        or len(normalized_indices) > plan.max_output_rows
+    ):
+        return None
+    if len(normalized_indices) > 0 and (
+        normalized_indices.min() < 0 or normalized_indices.max() >= plan.input_rows
+    ):
+        return None
+
+    output = np.empty(
+        (len(normalized_indices), *plan.tensor_type.shape),
+        dtype=plan.value_dtype,
+    )
+    if len(normalized_indices) > 0:
+        if not plan.chunk_views:
+            return None
+        _gather_into_output(
+            output,
+            normalized_indices,
+            plan.chunk_views,
+            plan.chunk_starts,
+            plan.chunk_ends,
+            plan.subbatch_rows,
+        )
+
+    return _wrap_tensor_output(output, plan.tensor_type, plan.values_per_row)
+
+
+def try_take_chunked_tensor(
+    column: pa.ChunkedArray,
+    normalized_indices: np.ndarray,
+) -> pa.Array | None:
+    """Take rows from an eligible Ray tensor column without concatenating chunks.
+
+    The fast path supports non-null, numeric, fixed-shape Ray V1/V2 tensor columns
+    with multiple chunks and already-normalized int64 indices. Every chunk must
+    expose a validated zero-copy NumPy view. The function preallocates only the
+    final output, gathers from source chunks in bounded subbatches, and wraps the
+    result with the original extension type. ``None`` means the caller must use
+    Ray's native column fallback; unexpected allocation or internal errors propagate.
+    """
+    if not _is_normalized_indices(normalized_indices):
+        return None
+    plan = try_prepare_chunked_tensor_take(
+        column,
+        max_output_rows=len(normalized_indices),
+    )
+    if plan is None:
+        return None
+    return try_take_prepared_chunked_tensor(plan, normalized_indices)
+
+
+def _tensor_take_subbatch_rows(total_rows: int, tensor_row_bytes: int) -> int:
+    """Choose the largest gather subbatch that fits the scratch-byte budget.
+
+    The estimate covers selected tensor payload plus temporary index/grouping arrays.
+    It intentionally excludes the required final output and its Arrow offsets.
+    """
+    if total_rows <= 0:
+        return 0
+    if tensor_row_bytes <= 0:
+        raise ValueError("tensor_row_bytes must be positive")
+
+    bytes_per_row = tensor_row_bytes + _INDEX_SCRATCH_BYTES_PER_ROW
+    return min(total_rows, TENSOR_TAKE_SCRATCH_CAP_BYTES // bytes_per_row)
+
+
+def _try_get_tensor_layout(tensor_type):
+    """Return fixed numeric tensor layout metadata, or ``None`` if unsupported.
+
+    The returned tuple is ``(values_per_row, row_bytes, numpy_dtype)``. Rejecting
+    unsupported scalar types or shapes keeps the fast path independent of object
+    conversion and variable-shape tensor semantics.
+    """
+    from ray.data._internal.tensor_extensions.arrow import (
+        ArrowTensorType,
+        ArrowTensorTypeV2,
+    )
+
+    if not isinstance(tensor_type, (ArrowTensorType, ArrowTensorTypeV2)):
+        return None
+
+    scalar_type = tensor_type.storage_type.value_type
+    if not (pa.types.is_integer(scalar_type) or pa.types.is_floating(scalar_type)):
+        return None
+    if scalar_type.bit_width % 8 != 0:
+        return None
+
+    shape = tensor_type.shape
+    if any(not isinstance(dimension, int) or dimension < 0 for dimension in shape):
+        return None
+    values_per_row = math.prod(shape)
+    if values_per_row <= 0:
+        return None
+
+    try:
+        value_dtype = np.dtype(scalar_type.to_pandas_dtype())
+    except (NotImplementedError, TypeError, ValueError):
+        return None
+    if value_dtype.hasobject or value_dtype.itemsize * 8 != scalar_type.bit_width:
+        return None
+
+    return values_per_row, values_per_row * value_dtype.itemsize, value_dtype
+
+
+def _is_normalized_indices(indices) -> bool:
+    """Check the internal index contract established by the table wrapper."""
+    return (
+        isinstance(indices, np.ndarray)
+        and indices.ndim == 1
+        and indices.dtype == np.dtype(np.int64)
+    )
+
+
+def _offsets_can_represent_output(
+    tensor_type, output_rows: int, values_per_row: int
+) -> bool:
+    """Check whether the original V1/V2 offset dtype can encode the output."""
+    offset_dtype = np.dtype(tensor_type.OFFSET_DTYPE.to_pandas_dtype())
+    return output_rows <= np.iinfo(offset_dtype).max // values_per_row
+
+
+def _try_get_zero_copy_chunk_view(chunk, tensor_type, values_per_row, value_dtype):
+    """Return a safe zero-copy tensor view, or ``None`` for column fallback.
+
+    Validation covers extension type identity, row/scalar nulls, sliced-array offset
+    origins, fixed-width row offsets, NumPy shape/dtype/contiguity, buffer ownership,
+    and the final pointer range. These checks prevent a view from silently copying or
+    addressing bytes outside the Arrow value buffer.
+    """
+    if chunk.type != tensor_type or chunk.null_count > 0:
+        return None
+
+    storage = chunk.storage
+    values = storage.values
+    if values.offset != 0:
+        return None
+    offsets = storage.offsets
+    if offsets.null_count > 0:
+        return None
+    try:
+        offset_values = offsets.to_numpy(zero_copy_only=True)
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError):
+        return None
+
+    if len(offset_values) != len(chunk) + 1:
+        return None
+    expected_start = chunk.offset * values_per_row
+    if int(offset_values[0]) != expected_start:
+        return None
+    if int(offset_values[-1]) - expected_start != len(chunk) * values_per_row:
+        return None
+    if not _has_fixed_width_offsets(offset_values, values_per_row):
+        return None
+
+    value_start = int(offset_values[0])
+    value_count = int(offset_values[-1]) - value_start
+    if values.slice(value_start, value_count).null_count > 0:
+        return None
+
+    try:
+        view = chunk.to_numpy(zero_copy_only=True)
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError):
+        return None
+
+    if (
+        view.shape != (len(chunk), *tensor_type.shape)
+        or view.dtype != value_dtype
+        or not view.flags.c_contiguous
+        or view.flags.owndata
+    ):
+        return None
+
+    data_buffer = chunk.buffers()[3]
+    if data_buffer is None:
+        return None
+    data_address = view.__array_interface__["data"][0]
+    if (
+        data_address < data_buffer.address
+        or data_address + view.nbytes > data_buffer.address + data_buffer.size
+    ):
+        return None
+    return view
+
+
+def _has_fixed_width_offsets(offsets: np.ndarray, values_per_row: int) -> bool:
+    """Validate fixed-size row offsets without allocating one full diff array."""
+    comparison_rows = max(
+        1,
+        _OFFSET_VALIDATION_BLOCK_BYTES // (offsets.dtype.itemsize + 1),
+    )
+    for start in range(0, len(offsets) - 1, comparison_rows):
+        stop = min(len(offsets) - 1, start + comparison_rows)
+        if not np.all(
+            offsets[start + 1 : stop + 1] - offsets[start:stop] == values_per_row
+        ):
+            return False
+    return True
+
+
+def _gather_into_output(
+    output: np.ndarray,
+    indices: np.ndarray,
+    chunks: tuple[np.ndarray, ...],
+    chunk_starts: np.ndarray,
+    chunk_ends: np.ndarray,
+    subbatch_rows: int,
+) -> None:
+    """Gather normalized row indices into a preallocated tensor output.
+
+    Each bounded subbatch maps global rows to source chunks once. Monotonic chunk IDs
+    preserve output order and use contiguous source slices when possible. Unordered
+    takes use mask grouping for at most 16 chunks; larger chunk sets sort output
+    positions once and scatter each chunk group back to its original positions.
+    """
+    for start in range(0, len(indices), subbatch_rows):
+        stop = min(len(indices), start + subbatch_rows)
+        subbatch_indices = indices[start:stop]
+        output_slice = output[start:stop]
+        chunk_ids = np.searchsorted(chunk_ends, subbatch_indices, side="right")
+        local_indices = subbatch_indices - chunk_starts[chunk_ids]
+
+        # Ordered chunk IDs need no sorting and may collapse to direct slices.
+        if np.all(chunk_ids[1:] >= chunk_ids[:-1]):
+            boundaries = np.flatnonzero(chunk_ids[1:] != chunk_ids[:-1]) + 1
+            group_start = 0
+            # Add the final sentinel lazily instead of materializing a Python tuple
+            # proportional to the number of chunk groups.
+            for group_stop in chain(boundaries, (len(chunk_ids),)):
+                chunk_id = chunk_ids[group_start]
+                group_indices = local_indices[group_start:group_stop]
+                if len(group_indices) <= 1 or np.all(
+                    group_indices[1:] == group_indices[:-1] + 1
+                ):
+                    source_start = int(group_indices[0])
+                    source_stop = source_start + len(group_indices)
+                    output_slice[group_start:group_stop] = chunks[chunk_id][
+                        source_start:source_stop
+                    ]
+                else:
+                    output_slice[group_start:group_stop] = chunks[chunk_id][
+                        group_indices
+                    ]
+                group_start = group_stop
+            continue
+
+        # For a few chunks, masks avoid the fixed cost of sorting every row.
+        if len(chunks) <= _MAX_MASK_GROUP_CHUNKS:
+            present_chunk_ids = np.flatnonzero(
+                np.bincount(chunk_ids, minlength=len(chunks))
+            )
+            for chunk_id in present_chunk_ids:
+                positions = np.flatnonzero(chunk_ids == chunk_id)
+                output_slice[positions] = chunks[chunk_id][local_indices[positions]]
+            continue
+
+        # For many chunks, sort positions once to avoid one full mask per chunk.
+        order = np.argsort(chunk_ids, kind="quicksort")
+        sorted_chunk_ids = chunk_ids[order]
+        boundaries = np.flatnonzero(sorted_chunk_ids[1:] != sorted_chunk_ids[:-1]) + 1
+        group_start = 0
+        for group_stop in chain(boundaries, (len(order),)):
+            positions = order[group_start:group_stop]
+            chunk_id = chunk_ids[positions[0]]
+            output_slice[positions] = chunks[chunk_id][local_indices[positions]]
+            group_start = group_stop
+
+
+def _wrap_tensor_output(output: np.ndarray, tensor_type, values_per_row: int):
+    """Wrap the owned NumPy output buffer with the original Ray tensor type.
+
+    Rebuilding data and offset arrays from buffers avoids another payload copy and
+    preserves the caller-visible V1/V2 extension type and table schema.
+    """
+    scalar_type = tensor_type.storage_type.value_type
+    data_array = pa.Array.from_buffers(
+        scalar_type,
+        output.size,
+        [None, pa.py_buffer(output)],
+    )
+    offset_dtype = np.dtype(tensor_type.OFFSET_DTYPE.to_pandas_dtype())
+    offsets = np.arange(
+        0,
+        (len(output) + 1) * values_per_row,
+        values_per_row,
+        dtype=offset_dtype,
+    )
+    storage = pa.Array.from_buffers(
+        tensor_type.storage_type,
+        len(output),
+        [None, pa.py_buffer(offsets)],
+        children=[data_array],
+    )
+    return tensor_type.wrap_array(storage)

--- a/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
+++ b/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
@@ -321,9 +321,10 @@ def _try_get_zero_copy_chunk_view(chunk, tensor_type, values_per_row, value_dtyp
     ):
         return None
 
-    data_buffer = chunk.buffers()[3]
-    if data_buffer is None:
+    buffers = chunk.buffers()
+    if len(buffers) < 4 or buffers[3] is None:
         return None
+    data_buffer = buffers[3]
     data_address = view.__array_interface__["data"][0]
     if (
         data_address < data_buffer.address

--- a/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
+++ b/python/ray/data/_internal/tensor_extensions/chunked_tensor_take.py
@@ -5,14 +5,19 @@ from typing import Any, NamedTuple
 import numpy as np
 import pyarrow as pa
 
+from ray._common.utils import env_bool
+
+ENABLE_CHUNKED_TENSOR_TAKE = env_bool(
+    "RAY_DATA_ENABLE_CHUNKED_TENSOR_TAKE",
+    True,
+)
+
 # Cap for simultaneously allocated per-subbatch NumPy gather/index buffers.
 # The final output, Arrow offsets, and zero-copy chunk-view metadata are excluded.
 TENSOR_TAKE_SCRATCH_CAP_BYTES = 8 * 1024 * 1024
-# Narrow large columns stay on Ray's native path because grouping can cost more
-# than the full-column copy it avoids. Small columns remain eligible because their
-# total copy cost is bounded.
+# Narrow columns stay on Ray's native path because grouping can cost more than
+# the full-column copy it avoids.
 _MIN_FAST_ROW_BYTES = 256
-_SMALL_COLUMN_ROWS = 512
 # Boolean-mask grouping is cheaper for a few chunks; sorting scales better once
 # the number of chunks makes repeated full-subbatch masks expensive.
 _MAX_MASK_GROUP_CHUNKS = 16
@@ -62,7 +67,7 @@ def _try_get_chunked_tensor_take_plan(
         return None
 
     values_per_row, row_bytes, value_dtype = layout
-    if input_rows >= _SMALL_COLUMN_ROWS and row_bytes < _MIN_FAST_ROW_BYTES:
+    if row_bytes < _MIN_FAST_ROW_BYTES:
         return None
     if not _offsets_can_represent_output(tensor_type, output_rows, values_per_row):
         return None
@@ -84,6 +89,9 @@ def try_prepare_chunked_tensor_take(
     max_output_rows: int,
 ) -> PreparedChunkedTensorTakePlan | None:
     """Validate and prepare one immutable chunked tensor source for repeated takes."""
+    if not ENABLE_CHUNKED_TENSOR_TAKE:
+        return None
+
     tensor_type = column.type
     if column.null_count > 0:
         return None

--- a/python/ray/data/tests/unit/test_chunked_tensor_take.py
+++ b/python/ray/data/tests/unit/test_chunked_tensor_take.py
@@ -221,10 +221,35 @@ def test_prepared_chunked_tensor_take_plan_owns_source_lifetime():
     np.testing.assert_array_equal(output.to_numpy(), expected)
 
 
-def test_chunked_tensor_take_fallbacks():
-    narrow, _ = _chunked_tensor(1024, 8, 4)
+@pytest.mark.parametrize("rows", [64, 1024])
+def test_narrow_chunked_tensor_take_falls_back(rows):
+    narrow, _ = _chunked_tensor(rows, 8, 4)
     assert try_prepare_chunked_tensor_take(narrow, max_output_rows=10) is None
 
+
+def test_chunked_tensor_take_can_be_disabled(monkeypatch):
+    column, values = _chunked_tensor(40, 64, 4)
+    indices = np.array([39, 1, 20], dtype=np.int64)
+    monkeypatch.setattr(chunked_tensor_take, "ENABLE_CHUNKED_TENSOR_TAKE", False)
+
+    assert try_prepare_chunked_tensor_take(column, max_output_rows=10) is None
+
+    table = pa.table({"tensor": column})
+    output = take_table(table, indices)
+    np.testing.assert_array_equal(
+        output.column("tensor").combine_chunks().to_numpy(),
+        values[indices],
+    )
+
+    prepared_table, plans = _prepare_local_shuffle_arrow_table(
+        table,
+        max_output_rows=10,
+    )
+    assert not plans
+    assert prepared_table.column("tensor").num_chunks == 1
+
+
+def test_chunked_tensor_take_fallbacks():
     single = pa.chunked_array([_chunked_tensor(20, 64, 2)[0].combine_chunks()])
     assert try_prepare_chunked_tensor_take(single, max_output_rows=10) is None
 

--- a/python/ray/data/tests/unit/test_chunked_tensor_take.py
+++ b/python/ray/data/tests/unit/test_chunked_tensor_take.py
@@ -384,6 +384,7 @@ def test_take_table_matches_single_chunk_tensor(indices):
         np.array([5], dtype=np.int64),
         np.array([1.0, 2.0]),
         np.array([[0, 1]], dtype=np.int64),
+        np.array([4, 0, 4, 2], dtype=">i8"),
     ],
 )
 def test_take_table_preserves_fallback_exceptions(indices):
@@ -480,6 +481,34 @@ def test_unexpected_chunked_tensor_take_errors_propagate(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="injected prepare failure"):
         try_prepare_chunked_tensor_take(column, max_output_rows=10)
+
+
+def test_chunked_tensor_take_falls_back_for_truncated_buffers():
+    column, _ = _chunked_tensor(40, 64, 4)
+    chunk = next(chunk for chunk in column.chunks if len(chunk) > 0)
+
+    class TruncatedBuffersChunk:
+        def __init__(self, array):
+            self._array = array
+
+        def __getattr__(self, name):
+            return getattr(self._array, name)
+
+        def __len__(self):
+            return len(self._array)
+
+        def buffers(self):
+            return self._array.buffers()[:3]
+
+    assert (
+        chunked_tensor_take._try_get_zero_copy_chunk_view(
+            TruncatedBuffersChunk(chunk),
+            column.type,
+            64,
+            np.dtype(np.float32),
+        )
+        is None
+    )
 
 
 def test_local_shuffle_tensor_fallbacks_and_prepared_take_errors(monkeypatch):

--- a/python/ray/data/tests/unit/test_chunked_tensor_take.py
+++ b/python/ray/data/tests/unit/test_chunked_tensor_take.py
@@ -1,0 +1,519 @@
+import gc
+import math
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from ray.data._internal import batcher as batcher_module
+from ray.data._internal.arrow_ops.transform_pyarrow import hash_partition, take_table
+from ray.data._internal.batcher import (
+    ShufflingBatcher,
+    _prepare_local_shuffle_arrow_table,
+    _take_prepared_arrow_table,
+)
+from ray.data._internal.tensor_extensions import chunked_tensor_take
+from ray.data._internal.tensor_extensions.arrow import (
+    ArrowTensorType,
+    ArrowTensorTypeV2,
+    ArrowVariableShapedTensorType,
+)
+from ray.data._internal.tensor_extensions.chunked_tensor_take import (
+    TENSOR_TAKE_SCRATCH_CAP_BYTES,
+    try_prepare_chunked_tensor_take,
+    try_take_chunked_tensor,
+    try_take_prepared_chunked_tensor,
+)
+
+
+def _tensor_array(tensor_type, values):
+    values = np.ascontiguousarray(values)
+    flat_values = values.reshape(-1)
+    scalar_type = tensor_type.storage_type.value_type
+    data = pa.Array.from_buffers(
+        scalar_type,
+        flat_values.size,
+        [None, pa.py_buffer(flat_values)],
+    )
+    values_per_row = math.prod(tensor_type.shape)
+    offsets = np.arange(
+        0,
+        (len(values) + 1) * values_per_row,
+        values_per_row,
+        dtype=np.dtype(tensor_type.OFFSET_DTYPE.to_pandas_dtype()),
+    )
+    storage = pa.Array.from_buffers(
+        tensor_type.storage_type,
+        len(values),
+        [None, pa.py_buffer(offsets)],
+        children=[data],
+    )
+    return tensor_type.wrap_array(storage)
+
+
+def _chunked_tensor(rows, width, chunks, tensor_cls=ArrowTensorTypeV2):
+    tensor_type = tensor_cls((width,), pa.float32())
+    values = np.arange(rows * width, dtype=np.float32).reshape(rows, width)
+    array = _tensor_array(tensor_type, values)
+    boundaries = np.linspace(0, rows, chunks + 1, dtype=np.int64)
+    arrays = [
+        array.slice(
+            int(boundaries[index]), int(boundaries[index + 1] - boundaries[index])
+        )
+        for index in range(chunks)
+    ]
+    arrays.insert(0, array.slice(0, 0))
+    arrays.insert(len(arrays) // 2, array.slice(rows // 2, 0))
+    arrays.append(array.slice(rows, 0))
+    return pa.chunked_array(arrays, type=tensor_type), values
+
+
+def _tensor_table(rows, width, chunks, *, start=0):
+    tensor_type = ArrowTensorTypeV2((width,), pa.float32())
+    row_ids = np.arange(start, start + rows, dtype=np.int64)
+    values = np.zeros((rows, width), dtype=np.float32)
+    values[:, 0] = row_ids.astype(np.float32)
+    array = _tensor_array(tensor_type, values)
+    boundaries = np.linspace(0, rows, chunks + 1, dtype=np.int64)
+    tensor_chunks = [
+        array.slice(
+            int(boundaries[index]), int(boundaries[index + 1] - boundaries[index])
+        )
+        for index in range(chunks)
+    ]
+    return pa.table(
+        {
+            "row_id": row_ids,
+            "tensor": pa.chunked_array(tensor_chunks, type=tensor_type),
+        }
+    )
+
+
+def _tensor_with_null(*, child_null):
+    rows = 40
+    width = 64
+    tensor_type = ArrowTensorTypeV2((width,), pa.float32())
+    values = np.arange(rows * width, dtype=np.float32)
+    validity = np.full((max(rows, values.size) + 7) // 8, 0xFF, dtype=np.uint8)
+    null_index = width + 1 if child_null else 5
+    validity[null_index // 8] &= np.uint8(~(1 << (null_index % 8)) & 0xFF)
+    data = pa.Array.from_buffers(
+        pa.float32(),
+        values.size,
+        [pa.py_buffer(validity) if child_null else None, pa.py_buffer(values)],
+        null_count=1 if child_null else 0,
+    )
+    offsets = np.arange(
+        0,
+        (rows + 1) * width,
+        width,
+        dtype=np.dtype(tensor_type.OFFSET_DTYPE.to_pandas_dtype()),
+    )
+    storage = pa.Array.from_buffers(
+        tensor_type.storage_type,
+        rows,
+        [pa.py_buffer(validity) if not child_null else None, pa.py_buffer(offsets)],
+        null_count=1 if not child_null else 0,
+        children=[data],
+    )
+    array = tensor_type.wrap_array(storage)
+    return pa.chunked_array([array.slice(0, 20), array.slice(20)], type=tensor_type)
+
+
+def _tensor_with_child_offset():
+    width = 64
+    tensor_type = ArrowTensorTypeV2((width,), pa.float32())
+    base = pa.array(np.arange(200, dtype=np.float32))
+    child = base.slice(10, 2 * width)
+    offsets = pa.array([0, width, 2 * width], type=tensor_type.OFFSET_DTYPE)
+    storage = pa.LargeListArray.from_arrays(offsets, child)
+    array = tensor_type.wrap_array(storage)
+    return pa.chunked_array([array.slice(0, 1), array.slice(1, 1)], type=tensor_type)
+
+
+def _zero_shape_chunked_tensor(rows, shape, tensor_cls):
+    tensor_type = tensor_cls(shape, pa.float32())
+    offsets = np.zeros(
+        rows + 1,
+        dtype=np.dtype(tensor_type.OFFSET_DTYPE.to_pandas_dtype()),
+    )
+    storage = pa.Array.from_buffers(
+        tensor_type.storage_type,
+        rows,
+        [None, pa.py_buffer(offsets)],
+        children=[pa.array([], type=pa.float32())],
+    )
+    array = tensor_type.wrap_array(storage)
+    split = rows // 2
+    return pa.chunked_array(
+        [array.slice(0, split), array.slice(split)],
+        type=tensor_type,
+    )
+
+
+@pytest.mark.parametrize("tensor_cls", [ArrowTensorType, ArrowTensorTypeV2])
+@pytest.mark.parametrize("chunks", [2, 17, 257])
+def test_chunked_tensor_take(tensor_cls, chunks):
+    rows = 514 if chunks == 257 else 64
+    column, values = _chunked_tensor(rows, 64, chunks, tensor_cls)
+    indices = np.array([rows - 1, 0, rows // 2, rows // 2, 3], dtype=np.int64)
+
+    plan = try_prepare_chunked_tensor_take(column, max_output_rows=len(indices))
+
+    assert plan is not None
+    assert plan.subbatch_rows * (plan.row_bytes + 64) <= TENSOR_TAKE_SCRATCH_CAP_BYTES
+    output = try_take_prepared_chunked_tensor(plan, indices)
+    assert output is not None
+    np.testing.assert_array_equal(output.to_numpy(), values[indices])
+    assert output.type == column.type
+    assert (
+        try_take_prepared_chunked_tensor(plan, np.array([rows, 0], dtype=np.int64))
+        is None
+    )
+    assert (
+        try_take_prepared_chunked_tensor(plan, np.array([3, -1], dtype=np.int64))
+        is None
+    )
+
+
+def test_chunked_tensor_take_across_scratch_subbatches():
+    rows = 1000
+    column, values = _chunked_tensor(rows, 3000, 17)
+    indices = np.random.default_rng(42).permutation(rows).astype(np.int64)
+    plan = try_prepare_chunked_tensor_take(column, max_output_rows=rows)
+
+    assert plan is not None
+    assert 0 < plan.subbatch_rows < rows
+    output = try_take_prepared_chunked_tensor(plan, indices)
+    assert output is not None
+    np.testing.assert_array_equal(output.to_numpy(), values[indices])
+
+
+def test_chunked_tensor_take_output_owns_source_lifetime():
+    column, values = _chunked_tensor(40, 64, 5)
+    expected = values[[39, 1, 20]].copy()
+
+    output = try_take_chunked_tensor(column, np.array([39, 1, 20], dtype=np.int64))
+
+    assert output is not None
+    del column
+    del values
+    gc.collect()
+    np.testing.assert_array_equal(output.to_numpy(), expected)
+
+
+def test_prepared_chunked_tensor_take_plan_owns_source_lifetime():
+    column, values = _chunked_tensor(40, 64, 5)
+    indices = np.array([39, 1, 20], dtype=np.int64)
+    expected = values[indices].copy()
+    plan = try_prepare_chunked_tensor_take(
+        column,
+        max_output_rows=len(indices),
+    )
+
+    assert plan is not None
+    del column
+    del values
+    gc.collect()
+
+    output = try_take_prepared_chunked_tensor(plan, indices)
+    assert output is not None
+    np.testing.assert_array_equal(output.to_numpy(), expected)
+
+
+def test_chunked_tensor_take_fallbacks():
+    narrow, _ = _chunked_tensor(1024, 8, 4)
+    assert try_prepare_chunked_tensor_take(narrow, max_output_rows=10) is None
+
+    single = pa.chunked_array([_chunked_tensor(20, 64, 2)[0].combine_chunks()])
+    assert try_prepare_chunked_tensor_take(single, max_output_rows=10) is None
+
+    nullable = _tensor_with_null(child_null=False)
+    assert nullable.null_count == 1
+    assert try_prepare_chunked_tensor_take(nullable, max_output_rows=10) is None
+
+    child_nullable = _tensor_with_null(child_null=True)
+    assert child_nullable.null_count == 0
+    assert child_nullable.chunk(0).storage.values.null_count == 1
+    assert try_prepare_chunked_tensor_take(child_nullable, max_output_rows=10) is None
+
+    variable_type = ArrowVariableShapedTensorType(pa.float32(), ndim=1)
+    variable_storage = pa.array(
+        [
+            {"data": [1.0, 2.0], "shape": [2]},
+            {"data": [3.0], "shape": [1]},
+        ],
+        type=variable_type.storage_type,
+    )
+    variable = variable_type.wrap_array(variable_storage)
+    variable_chunked = pa.chunked_array(
+        [variable.slice(0, 1), variable.slice(1)], type=variable_type
+    )
+    assert try_prepare_chunked_tensor_take(variable_chunked, max_output_rows=2) is None
+
+    child_offset = _tensor_with_child_offset()
+    assert child_offset.chunk(0).storage.values.offset == 10
+    assert try_prepare_chunked_tensor_take(child_offset, max_output_rows=2) is None
+    child_offset_output = (
+        take_table(pa.table({"tensor": child_offset}), np.array([0, 1], dtype=np.int64))
+        .column("tensor")
+        .chunk(0)
+    )
+    assert child_offset_output.storage.to_pylist() == [
+        list(np.arange(10, 74, dtype=np.float32)),
+        list(np.arange(74, 138, dtype=np.float32)),
+    ]
+
+    if hasattr(pa, "FixedShapeTensorArray"):
+        native = pa.FixedShapeTensorArray.from_numpy_ndarray(
+            np.arange(40 * 64, dtype=np.float32).reshape(40, 64)
+        )
+        native_chunked = pa.chunked_array([native.slice(0, 20), native.slice(20)])
+        assert (
+            try_prepare_chunked_tensor_take(native_chunked, max_output_rows=10) is None
+        )
+
+
+@pytest.mark.parametrize("tensor_cls", [ArrowTensorType, ArrowTensorTypeV2])
+def test_hash_partition_preserves_multichunk_tensor(tensor_cls):
+    rows = 97
+    tensor, values = _chunked_tensor(rows, 64, 17, tensor_cls)
+    table = pa.table(
+        {
+            "key": np.arange(rows, dtype=np.int64) % 11,
+            "row_id": np.arange(rows, dtype=np.int64),
+            "tensor": tensor,
+        }
+    )
+
+    partitions = hash_partition(table, hash_cols=["key"], num_partitions=7)
+    combined = pa.concat_tables(list(partitions.values()))
+    row_ids = combined.column("row_id").combine_chunks().to_numpy()
+    order = np.argsort(row_ids)
+    actual_tensor = combined.column("tensor").combine_chunks().to_numpy()
+
+    assert combined.schema == table.schema
+    np.testing.assert_array_equal(row_ids[order], np.arange(rows, dtype=np.int64))
+    np.testing.assert_array_equal(actual_tensor[order], values)
+
+
+@pytest.mark.parametrize("tensor_cls", [ArrowTensorType, ArrowTensorTypeV2])
+@pytest.mark.parametrize("rows,shape", [(3, (0,)), (3, (0, 2)), (0, (0,))])
+def test_zero_shape_tensor_falls_back(tensor_cls, rows, shape):
+    tensor = _zero_shape_chunked_tensor(rows, shape, tensor_cls)
+    table = pa.table({"tensor": tensor})
+    reference = pa.table({"tensor": tensor.combine_chunks()})
+    indices = np.arange(rows, dtype=np.int64)
+
+    assert try_prepare_chunked_tensor_take(tensor, max_output_rows=max(1, rows)) is None
+    actual = take_table(table, indices)
+    expected = take_table(reference, indices)
+
+    assert actual.schema == expected.schema
+    assert actual.num_rows == expected.num_rows == rows
+    assert (
+        actual.column("tensor").combine_chunks().storage.to_pylist()
+        == expected.column("tensor").combine_chunks().storage.to_pylist()
+    )
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        [4, 0, 4, 2],
+        np.array([4, 0, 4, 2], dtype=np.int32),
+        np.array([4, 0, 4, 2], dtype=np.int64),
+        np.array([4, 0, 4, 2], dtype=np.uint64),
+        pa.array([4, 0, 4, 2], type=pa.int64()),
+        np.ma.array([0, 1], mask=[False, True]),
+        pa.array([0, None], type=pa.int64()),
+    ],
+)
+def test_take_table_matches_single_chunk_tensor(indices):
+    table = _tensor_table(5, 64, 2)
+    reference = pa.table(
+        {
+            "row_id": table.column("row_id").combine_chunks(),
+            "tensor": table.column("tensor").combine_chunks(),
+        }
+    )
+
+    actual = take_table(table, indices)
+    expected = take_table(reference, indices)
+
+    assert (
+        actual.column("row_id").combine_chunks().to_pylist()
+        == expected.column("row_id").combine_chunks().to_pylist()
+    )
+    assert (
+        actual.column("tensor").combine_chunks().storage.to_pylist()
+        == expected.column("tensor").combine_chunks().storage.to_pylist()
+    )
+    assert actual.schema == expected.schema
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        np.array([3, -1], dtype=np.int64),
+        np.array([5], dtype=np.int64),
+        np.array([1.0, 2.0]),
+        np.array([[0, 1]], dtype=np.int64),
+    ],
+)
+def test_take_table_preserves_fallback_exceptions(indices):
+    table = _tensor_table(5, 64, 2)
+    reference = pa.table(
+        {
+            "row_id": table.column("row_id").combine_chunks(),
+            "tensor": table.column("tensor").combine_chunks(),
+        }
+    )
+
+    with pytest.raises(Exception) as expected_error:
+        take_table(reference, indices)
+    with pytest.raises(type(expected_error.value)):
+        take_table(table, indices)
+
+
+@pytest.mark.parametrize("indices", [[1, True], [True, 1], []])
+def test_take_table_tensor_only_preserves_list_exceptions(indices):
+    table = _tensor_table(5, 64, 2).select(["tensor"])
+    reference = pa.table({"tensor": table.column("tensor").combine_chunks()})
+
+    with pytest.raises(Exception) as expected_error:
+        take_table(reference, indices)
+    with pytest.raises(type(expected_error.value)):
+        take_table(table, indices)
+
+
+def _consume(table, *, batch_size, buffer_rows, source_rows, seed):
+    batcher = ShufflingBatcher(
+        batch_size=batch_size,
+        shuffle_buffer_min_size=buffer_rows,
+        shuffle_seed=seed,
+    )
+    batches = []
+
+    def consume_ready():
+        while batcher.has_batch():
+            batches.append(batcher.next_batch())
+
+    for start in range(0, len(table), source_rows):
+        batcher.add(table.slice(start, min(source_rows, len(table) - start)))
+        consume_ready()
+    batcher.done_adding()
+    consume_ready()
+    if batcher.has_any():
+        batches.append(batcher.next_batch())
+    return batches, batcher
+
+
+def test_shuffling_batcher_reuses_chunked_tensor_plan(monkeypatch):
+    monkeypatch.setattr(
+        batcher_module, "get_total_obj_store_mem_on_node", lambda: 1 << 60
+    )
+    tensor_table = _tensor_table(79, 64, 20)
+    plain_table = tensor_table.select(["row_id"])
+
+    tensor_batches, batcher = _consume(
+        tensor_table, batch_size=9, buffer_rows=27, source_rows=4, seed=51
+    )
+    plain_batches, _ = _consume(
+        plain_table, batch_size=9, buffer_rows=27, source_rows=4, seed=51
+    )
+
+    tensor_ids = [
+        batch.column("row_id").combine_chunks().to_numpy() for batch in tensor_batches
+    ]
+    plain_ids = [
+        batch.column("row_id").combine_chunks().to_numpy() for batch in plain_batches
+    ]
+    assert len(tensor_ids) == len(plain_ids)
+    for actual, expected in zip(tensor_ids, plain_ids):
+        np.testing.assert_array_equal(actual, expected)
+    for batch, ids in zip(tensor_batches, tensor_ids):
+        tensor = batch.column("tensor").chunk(0).to_numpy()
+        np.testing.assert_array_equal(tensor[:, 0], ids.astype(np.float32))
+
+    assert sum(len(ids) for ids in tensor_ids) == len(tensor_table)
+    assert batcher._batch_head == len(batcher._shuffled_indices)
+    assert batcher._prepared_tensor_take_plans
+    assert not hasattr(batcher, "_prefetched_block")
+    for plan in batcher._prepared_tensor_take_plans.values():
+        assert plan.max_output_rows <= 9
+
+
+def test_unexpected_chunked_tensor_take_errors_propagate(monkeypatch):
+    column, _ = _chunked_tensor(40, 64, 4)
+
+    def raise_prepare(*args, **kwargs):
+        raise RuntimeError("injected prepare failure")
+
+    monkeypatch.setattr(
+        chunked_tensor_take, "_try_get_zero_copy_chunk_view", raise_prepare
+    )
+    with pytest.raises(RuntimeError, match="injected prepare failure"):
+        try_prepare_chunked_tensor_take(column, max_output_rows=10)
+
+
+def test_local_shuffle_tensor_fallbacks_and_prepared_take_errors(monkeypatch):
+    plain = pa.table({"value": pa.chunked_array([pa.array([1, 2]), pa.array([3, 4])])})
+
+    def fail_plain_tensor_prepare(*args, **kwargs):
+        raise AssertionError("Plain Arrow fast path called tensor prepare")
+
+    with monkeypatch.context() as plain_context:
+        plain_context.setattr(
+            chunked_tensor_take,
+            "try_prepare_chunked_tensor_take",
+            fail_plain_tensor_prepare,
+        )
+        prepared_plain, plain_plans = _prepare_local_shuffle_arrow_table(
+            plain, max_output_rows=2
+        )
+    assert not plain_plans
+    assert prepared_plain.column("value").num_chunks == 1
+
+    narrow, _ = _chunked_tensor(1024, 8, 4)
+    prepared_narrow, narrow_plans = _prepare_local_shuffle_arrow_table(
+        pa.table({"tensor": narrow}), max_output_rows=10
+    )
+    assert not narrow_plans
+    assert prepared_narrow.column("tensor").num_chunks == 1
+
+    nullable = _tensor_with_null(child_null=False)
+    fallback_table, fallback_plans = _prepare_local_shuffle_arrow_table(
+        pa.table({"tensor": nullable}), max_output_rows=10
+    )
+    assert not fallback_plans
+    assert fallback_table.column("tensor").num_chunks == 1
+
+    table = _tensor_table(40, 64, 4)
+    prepared_table, plans = _prepare_local_shuffle_arrow_table(
+        table, max_output_rows=10
+    )
+    assert plans
+    indices = np.arange(10, dtype=np.int64)
+
+    monkeypatch.setattr(
+        chunked_tensor_take,
+        "try_take_prepared_chunked_tensor",
+        lambda *args, **kwargs: None,
+    )
+    assert _take_prepared_arrow_table(prepared_table, indices, plans) is None
+
+    def raise_take(*args, **kwargs):
+        raise RuntimeError("injected take failure")
+
+    monkeypatch.setattr(
+        chunked_tensor_take, "try_take_prepared_chunked_tensor", raise_take
+    )
+    with pytest.raises(RuntimeError, match="injected take failure"):
+        _take_prepared_arrow_table(prepared_table, indices, plans)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
> **Fork-only preview:** This draft PR is for reviewing the code and proposed
> contribution in `OneSizeFitsQuorum/ray`. It has not been submitted to
> `ray-project/ray`.

## Description

This change avoids concatenating eligible multi-chunk Ray tensor extension
columns before row takes. Local shuffle is the primary use case, but the
one-shot path is shared by other PyArrow-backed Ray Data operations.

For a shuffle buffer containing `N` tensor rows, each with width `D`, producing
a `K`-row batch currently pays for a full `O(N × D)` column concatenation before
the required `O(K × D)` output copy. The proposed path gathers selected rows
directly from the source chunks, bringing the primary copy cost closer to the
unavoidable `O(K × D)`.

There are two integration levels:

- `take_table()` prepares and executes a one-shot direct gather for general
  Arrow row-take operations.
- `ShufflingBatcher` prepares validated, generation-scoped chunk metadata once
  per compaction and reuses it for each output batch. The plan is discarded and
  rebuilt after the next compaction.

Only local shuffle currently reuses a prepared plan across multiple takes.

## Implementation

- Add `PreparedChunkedTensorTakePlan` for validated Ray tensor V1/V2 chunk
  metadata.
- Retain zero-copy NumPy views of source chunks and their global row
  boundaries.
- Map global row indices to chunk-local rows and gather directly into the final
  contiguous tensor output.
- Divide wide-tensor gathers into bounded subbatches.
- Cap additional gather and index scratch memory at 8 MiB per subbatch.
- Integrate direct gathering with `take_table()`.
- Reuse prepared plans from `ShufflingBatcher.next_batch()`.
- Add `RAY_DATA_ENABLE_CHUNKED_TENSOR_TAKE` as a default-on operational
  fallback switch for both integration levels.
- Continue combining ordinary Arrow columns through the existing path.
- Preserve list-index parsing, exception behavior, and conservative fallback.

## Ray Data paths

Because `ArrowBlockAccessor.take()` delegates to `take_table()`, the one-shot
fast path is already reachable from:

- general Arrow block row takes;
- hash partitioning and hash shuffle;
- PyArrow sort;
- random shuffle and shuffle-based repartition;
- `concat_and_sort()`;
- projection of Arrow-join-unsupported tensor columns after a join.

Local shuffle has the largest expected gain because the same prepared plan is
reused to emit multiple batches and typically selects `K < N` rows at a time.
General takes and join projections can have the same favorable `K < N`
relationship.

Sort, random shuffle, and hash partition usually perform a full permutation
with `K = N`. They still avoid the extra full-source concatenation and its
temporary allocation, but must copy the full output tensor once. The performance
results below measure the local-shuffle use case; they do not claim measured
speedups for every reachable operator.

Pandas blocks, Polars sort paths, and direct `pyarrow.Table.take()` calls do not
use this fast path. Contiguous Arrow slicing remains on its existing zero-copy
path.

## Safety and fallback behavior

The fast path is limited to non-null numeric fixed-shape `ArrowTensorType` and
`ArrowTensorTypeV2` columns with multiple chunks and validated contiguous child
buffers.

The existing implementation remains in use for:

- null tensor rows or child values;
- variable-shaped and native PyArrow tensors;
- single-chunk tensor columns;
- all tensor rows narrower than 256 bytes;
- unsupported scalar dtypes and shapes;
- zero-sized tensor shapes;
- non-zero child offsets;
- unrepresentable output offsets;
- masked, nullable, non-native, non-integral, negative, out-of-range, or
  multidimensional indices.

Recognized unsupported layouts return to the existing concatenate/take path.
Setting `RAY_DATA_ENABLE_CHUNKED_TENSOR_TAKE=0` disables the fast path
entirely. Unexpected allocation and internal errors are propagated.

## Tests

The focused and existing regression suites cover:

- Ray tensor V1/V2 with 2, 17, and 257 source chunks;
- empty chunks and multiple 8 MiB scratch subbatches;
- shuffled, duplicated, and cross-boundary indices;
- prepared-plan and output buffer lifetime;
- local-shuffle compaction and plan rebuilding;
- fixed-seed row-order parity;
- hash partitioning with a multi-chunk tensor data column;
- nullable, child-offset, variable-shaped, native tensor, narrow, single-chunk,
  zero-sized-shape, and zero-row fallbacks;
- non-native-index and truncated-buffer-layout fallbacks;
- environment-controlled fallback for general takes and local shuffle;
- invalid-index exception parity;
- prepared-take fallback and unexpected-error propagation.

Commands:

```bash
python -m pytest \
  python/ray/data/tests/unit/test_chunked_tensor_take.py \
  python/ray/data/tests/unit/test_transform_pyarrow.py \
  python/ray/data/tests/test_batcher.py \
  -q
```

Result:

```text
137 passed in 77.66s
```

The complete repository hooks were run against all four changed files:

```bash
pre-commit run
```

All applicable hooks passed, including Ruff, Black, pydoclint, Semgrep,
docstyle, AST, and Ray import-order checks.

The correctness probe produced byte-identical baseline, patched, and
packaged-runtime outputs.

## Synthetic performance

The primary local-shuffle scenario uses 100,000 rows of `float32[3000]`,
10,000-row batches, a 100,000-row shuffle buffer, and four independently paired
baseline/patch processes.

| Case | Result |
|---|---:|
| Primary geometric-mean speedup | `9.80x` |
| Bootstrap 95% CI | `[9.68x, 9.89x]` |
| Patch / baseline peak USS | `0.139` |
| Width-64 streaming | `4.92x` speedup |
| 100 source chunks | `8.97x` speedup |
| Narrow fallback patch / baseline | `0.964` |
| Plain Arrow patch / baseline | `0.972` |
| Single-chunk control | Fast path disabled; no regression observed |

The summary was regenerated from 22 raw result files and matched the recorded
output byte-for-byte. All predefined performance, variance, and fallback
regression gates passed.

## End-to-end Ray Train + Ray Data validation

In the original Ray Train + Ray Data use case, workers consume batches
containing wide multi-chunk tensors from a locally shuffled dataset. The
workload configuration was:

| Setting | Value |
|---|---:|
| Training rows | `60,074,872` |
| Validation rows | `6,444,594` |
| Row layout | `float32[30, 100]` tensor plus one `float32` label |
| Bytes per row | approximately `12,004` |
| Training blocks | `5,373` (approximately `11,181` rows per block) |
| Validation blocks | approximately `577` |
| Training payload | approximately `721 GB` (`672 GiB`) |
| Validation payload | approximately `77 GB` (`72 GiB`) |
| Trainer workers | `8`, using `8` GPUs |
| Batch size | `10,000` rows |
| Local shuffle buffer | `100,000` rows |
| Epochs completed | `5` |
| Shuffle settings | `shuffle=True`, `shuffle_ratio=1.0`, `block_random_shuffle=True` |
| Software | Ray `2.56.1`, Python `3.11.9`, PyArrow `17.0.0`, NumPy `1.26.4` |

The workload did not include an application-level filter or sort. The baseline
and patch runs used hardware-equivalent nodes. The end-to-end comparison
produced:

| Metric | Patch / baseline | Equivalent change |
|---|---:|---:|
| Epoch duration geometric mean | `0.221` | approximately `4.52x` faster |
| Final epoch duration | `0.208` | approximately `4.80x` faster |
| Trial duration | `0.233` | approximately `4.30x` faster |
| Parent duration | `0.259` | approximately `3.85x` faster |
| Worker peak USS | `0.918` | approximately `8.2%` lower |
| Object-store peak usage | `0.870` | approximately `13.0%` lower |

The validation completed without object spilling, object-store fallback, data
task failures, retries, worker startup failures, node failures, or container
restarts.

## Duplicate-work check

On 2026-07-23, I searched open Ray Issues and PRs for `chunked tensor`,
`multi-chunk tensor`, `tensor take`, `local shuffle tensor`, and
`ShufflingBatcher`. I found no open work addressing this optimization.

PR #64576 touches `transform_pyarrow.py`, but only changes an assertion error
message and unrelated operator bounds checks. It does not overlap this design or
implementation.

AI assistance was used in preparing this change.
